### PR TITLE
feat(submission): phase 3 — assessment submission, AI scoring & processing UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DATABASE_URL=postgresql://user:password@host:port/dbname
 
 # ── AI Scoring (OpenRouter) ───────────────────
 OPENROUTER_API_KEY=sk-or-...
+AI_MODEL=anthropic/claude-sonnet-4
 
 # ── Email (Mailgun) ───────────────────────────
 MAILGUN_API_KEY=...

--- a/src/app/api/assessment/submit/route.ts
+++ b/src/app/api/assessment/submit/route.ts
@@ -1,0 +1,153 @@
+import { eq } from 'drizzle-orm';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { scoreAssessment } from '@/lib/ai/scoring';
+import { hashIp } from '@/lib/hash';
+import { checkRateLimit } from '@/lib/middleware/rate-limit';
+import { verifyRecaptchaToken } from '@/lib/recaptcha';
+import { SubmissionBodySchema } from '@/lib/validation/submission-schema';
+import { db } from '@/libs/DB';
+import { Env } from '@/libs/Env';
+import { assessments } from '@/models/Schema';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    // ── 1. Extract and hash the client IP ──────────────────────────────────
+    const forwarded = request.headers.get('x-forwarded-for');
+    const rawIp = forwarded
+      ? (forwarded.split(',')[0]?.trim() ?? '127.0.0.1')
+      : (request.headers.get('x-real-ip') ?? '127.0.0.1');
+    const ipHash = hashIp(rawIp);
+
+    // ── 2. Rate limiting ────────────────────────────────────────────────────
+    const rateLimit = await checkRateLimit(ipHash, 'assessment_submit');
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'rate_limited',
+          message: 'Too many submissions. Please try again later.',
+          retryAfter: rateLimit.retryAfter,
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(rateLimit.retryAfter) },
+        },
+      );
+    }
+
+    // ── 3. Parse request body ───────────────────────────────────────────────
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'invalid_json', message: 'Request body must be valid JSON.' },
+        { status: 400 },
+      );
+    }
+
+    // ── 4. Validate with Zod ────────────────────────────────────────────────
+    const parsed = SubmissionBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const path = issue.path.join('.');
+        if (!errors[path]) {
+          errors[path] = issue.message;
+        }
+      }
+      return NextResponse.json({ success: false, errors }, { status: 400 });
+    }
+
+    const { responses, recaptchaToken } = parsed.data;
+
+    // ── 5. Verify reCAPTCHA ─────────────────────────────────────────────────
+    // Skip verification when secret key is not configured (e.g. local dev)
+    let recaptchaScore: number | null = null;
+    if (Env.RECAPTCHA_SECRET_KEY && recaptchaToken) {
+      const captcha = await verifyRecaptchaToken(recaptchaToken, Env.RECAPTCHA_SECRET_KEY);
+      if (!captcha.success) {
+        return NextResponse.json(
+          { success: false, error: 'captcha_failed', message: 'Bot check failed. Please try again.' },
+          { status: 403 },
+        );
+      }
+      recaptchaScore = captcha.score;
+      // Scores below 0.5 are likely bots — still score with AI but note the low score
+    }
+
+    // ── 6. Save assessment to DB (ai_scored: false initially) ───────────────
+    const insertResult = await db
+      .insert(assessments)
+      .values({
+        contactName: responses.contactName,
+        contactEmail: responses.contactEmail,
+        contactCompany: responses.contactCompany ?? null,
+        contactLinkedin: responses.contactLinkedin ?? null,
+        contactSource: responses.contactSource ?? null,
+        responses: responses as unknown as Record<string, unknown>,
+        aiScored: false,
+        ipHash,
+        recaptchaScore: recaptchaScore ?? undefined,
+      })
+      .returning({ id: assessments.id });
+
+    const savedId = insertResult[0]?.id;
+    if (!savedId) {
+      return NextResponse.json(
+        { success: false, error: 'database_error', message: 'Failed to save assessment.' },
+        { status: 500 },
+      );
+    }
+
+    // ── 7. AI Scoring ────────────────────────────────────────────────────────
+    const scoringStart = Date.now();
+    let aiPending = false;
+
+    try {
+      const aiResult = await scoreAssessment(responses);
+      const processingTimeMs = Date.now() - scoringStart;
+
+      // Build categoryScores map: { "Problem-Market Fit": 72, ... }
+      const categoryScores: Record<string, number> = {};
+      for (const cat of aiResult.categories) {
+        categoryScores[cat.name] = cat.score;
+      }
+
+      await db
+        .update(assessments)
+        .set({
+          overallScore: aiResult.overallScore,
+          readinessLevel: aiResult.readinessLevel,
+          categoryScores: categoryScores as unknown as Record<string, unknown>,
+          topGaps: aiResult.topGaps as unknown as Record<string, unknown>[],
+          recommendations: aiResult.mediumTermRecommendations as unknown as Record<string, unknown>,
+          quickWins: aiResult.quickWins as unknown as Record<string, unknown>,
+          aiScored: true,
+          aiModel: process.env.AI_MODEL ?? 'anthropic/claude-sonnet-4',
+          aiProcessingTimeMs: processingTimeMs,
+        })
+        .where(eq(assessments.id, savedId));
+    } catch (scoringError) {
+      // AI failed — flag for manual review, but still redirect user to results
+      aiPending = true;
+      console.error('[assessment/submit] AI scoring failed:', scoringError);
+    }
+
+    // ── 8. Return success ───────────────────────────────────────────────────
+    return NextResponse.json({
+      success: true,
+      assessmentId: savedId,
+      redirectUrl: `/results/${savedId}`,
+      ...(aiPending ? { aiPending: true } : {}),
+    });
+  } catch (error) {
+    console.error('[assessment/submit] Unexpected error:', error);
+    return NextResponse.json(
+      { success: false, error: 'internal_error', message: 'Something went wrong. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/assessment/ProcessingScreen.tsx
+++ b/src/components/assessment/ProcessingScreen.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { AssessmentFormData } from '@/types/assessment';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type SubmitApiResponse =
+  | { success: true; assessmentId: string; redirectUrl: string; aiPending?: boolean }
+  | { success: false; error: string; errors?: Record<string, string>; retryAfter?: number; message?: string };
+
+type ErrorState =
+  | { kind: 'rate_limited'; retryAfter: number; message: string }
+  | { kind: 'captcha_failed' }
+  | { kind: 'validation_error'; errors: Record<string, string> }
+  | { kind: 'network_error' }
+  | { kind: 'internal_error'; message: string };
+
+type ProcessingScreenProps = {
+  formData: AssessmentFormData;
+  recaptchaToken: string;
+  onReturnToForm: (errors?: Record<string, string>) => void;
+};
+
+// ── Step definitions ──────────────────────────────────────────────────────────
+
+const STEPS = ['Analyzing responses', 'Scoring 10 criteria', 'Generating recommendations'] as const;
+type StepStatus = 'pending' | 'active' | 'complete';
+
+function getStepStatus(stepIndex: number, phase: number): StepStatus {
+  if (phase > stepIndex) {
+    return 'complete';
+  }
+  if (phase === stepIndex) {
+    return 'active';
+  }
+  return 'pending';
+}
+
+// ── API call ──────────────────────────────────────────────────────────────────
+
+async function submitAssessment(
+  formData: AssessmentFormData,
+  recaptchaToken: string,
+): Promise<SubmitApiResponse> {
+  const response = await fetch('/api/assessment/submit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ responses: formData, recaptchaToken }),
+  });
+  return response.json() as Promise<SubmitApiResponse>;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SpinnerCircle({ size = 32 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      className="animate-spin"
+      aria-hidden="true"
+    >
+      <circle cx="16" cy="16" r="13" stroke="#e2e8f0" strokeWidth="3" />
+      <path
+        d="M 16 3 A 13 13 0 0 1 29 16"
+        stroke="#2563eb"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function CheckCircle() {
+  return (
+    <div className="flex size-8 items-center justify-center rounded-full bg-score-green">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M3 8l3.5 3.5L13 5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </div>
+  );
+}
+
+function PendingCircle() {
+  return (
+    <div
+      className="size-8 rounded-full border-2 border-card-border"
+      aria-hidden="true"
+    />
+  );
+}
+
+function StepItem({ label, status }: { label: string; status: StepStatus }) {
+  const labelColor
+    = status === 'complete'
+      ? 'text-text-primary'
+      : status === 'active'
+        ? 'text-accent-blue'
+        : 'text-text-muted';
+
+  const statusText
+    = status === 'complete' ? 'Complete' : status === 'active' ? 'Processing...' : 'Waiting';
+
+  const statusColor
+    = status === 'complete'
+      ? 'text-score-green'
+      : status === 'active'
+        ? 'text-accent-blue'
+        : 'text-text-muted';
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="shrink-0">
+        {status === 'complete' && <CheckCircle />}
+        {status === 'active' && <SpinnerCircle />}
+        {status === 'pending' && <PendingCircle />}
+      </div>
+
+      <div className="flex flex-1 items-center justify-between">
+        <span className={`text-sm font-medium ${labelColor}`}>
+          {label}
+        </span>
+        <span className={`text-xs ${statusColor}`}>
+          {statusText}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Error display ─────────────────────────────────────────────────────────────
+
+function ErrorCard({
+  error,
+  onRetry,
+  onReturnToForm,
+}: {
+  error: ErrorState;
+  onRetry: () => void;
+  onReturnToForm: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-card-border bg-white p-8 shadow-card">
+      <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-score-red-bg text-score-red">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </div>
+
+      {error.kind === 'rate_limited' && (
+        <>
+          <h2 className="mb-2 text-xl font-semibold text-text-primary">Submission limit reached</h2>
+          <p className="mb-6 text-sm text-text-secondary">
+            {error.message}
+            {' '}
+            Please wait
+            {' '}
+            {Math.ceil(error.retryAfter / 60)}
+            {' '}
+            minutes before trying again.
+          </p>
+          <button
+            type="button"
+            onClick={onReturnToForm}
+            className="rounded-lg bg-accent-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-blue-hover"
+          >
+            Back to form
+          </button>
+        </>
+      )}
+
+      {error.kind === 'captcha_failed' && (
+        <>
+          <h2 className="mb-2 text-xl font-semibold text-text-primary">Verification failed</h2>
+          <p className="mb-6 text-sm text-text-secondary">
+            We could not verify your submission. Please try again.
+          </p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded-lg bg-accent-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-blue-hover"
+          >
+            Try again
+          </button>
+        </>
+      )}
+
+      {error.kind === 'validation_error' && (
+        <>
+          <h2 className="mb-2 text-xl font-semibold text-text-primary">Validation error</h2>
+          <p className="mb-6 text-sm text-text-secondary">
+            Some fields need to be corrected. Please go back and fix the highlighted issues.
+          </p>
+          <button
+            type="button"
+            onClick={onReturnToForm}
+            className="rounded-lg bg-accent-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-blue-hover"
+          >
+            Back to form
+          </button>
+        </>
+      )}
+
+      {error.kind === 'network_error' && (
+        <>
+          <h2 className="mb-2 text-xl font-semibold text-text-primary">Connection error</h2>
+          <p className="mb-6 text-sm text-text-secondary">
+            Could not reach the server. Check your connection and try again.
+          </p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-lg bg-accent-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-blue-hover"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={onReturnToForm}
+              className="rounded-lg border border-card-border px-5 py-2.5 text-sm font-semibold text-text-secondary hover:bg-page-bg"
+            >
+              Back to form
+            </button>
+          </div>
+        </>
+      )}
+
+      {error.kind === 'internal_error' && (
+        <>
+          <h2 className="mb-2 text-xl font-semibold text-text-primary">Something went wrong</h2>
+          <p className="mb-6 text-sm text-text-secondary">
+            {error.message}
+          </p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-lg bg-accent-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-blue-hover"
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={onReturnToForm}
+              className="rounded-lg border border-card-border px-5 py-2.5 text-sm font-semibold text-text-secondary hover:bg-page-bg"
+            >
+              Back to form
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Main ProcessingScreen component ──────────────────────────────────────────
+
+export default function ProcessingScreen({
+  formData,
+  recaptchaToken,
+  onReturnToForm,
+}: ProcessingScreenProps) {
+  // phase 0 = Analyzing (step 0 active)
+  // phase 1 = Scoring (step 1 active)
+  // phase 2 = Generating (step 2 active)
+  // phase 3 = Done (all complete, redirecting)
+  const [phase, setPhase] = useState<0 | 1 | 2 | 3>(0);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const apiResultRef = useRef<{ redirectUrl: string } | null>(null);
+  const [attemptKey, setAttemptKey] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    const startTime = Date.now();
+
+    const run = async () => {
+      try {
+        const result = await submitAssessment(formData, recaptchaToken);
+
+        if (!mounted) {
+          return;
+        }
+
+        if (!result.success) {
+          if (result.error === 'rate_limited') {
+            setError({ kind: 'rate_limited', retryAfter: result.retryAfter ?? 3600, message: result.message ?? '' });
+          } else if (result.error === 'captcha_failed') {
+            setError({ kind: 'captcha_failed' });
+          } else if (result.errors) {
+            setError({ kind: 'validation_error', errors: result.errors });
+          } else {
+            setError({ kind: 'internal_error', message: result.message ?? 'Something went wrong. Please try again.' });
+          }
+          return;
+        }
+
+        // Ensure minimum 1.5s elapsed so user sees step 0 → 1 transition
+        const elapsed = Date.now() - startTime;
+        const minWait = Math.max(0, 1500 - elapsed);
+        await new Promise<void>(resolve => setTimeout(resolve, minWait));
+
+        if (!mounted) {
+          return;
+        }
+
+        apiResultRef.current = { redirectUrl: result.redirectUrl };
+        setPhase(2);
+
+        // Show "Generating recommendations" briefly, then redirect
+        setTimeout(() => {
+          if (mounted) {
+            setPhase(3);
+            window.location.href = result.redirectUrl;
+          }
+        }, 800);
+      } catch {
+        if (mounted) {
+          setError({ kind: 'network_error' });
+        }
+      }
+    };
+
+    // Advance step 0 → 1 after 1.5 seconds regardless of API state
+    const step0Timer = setTimeout(() => {
+      if (mounted) {
+        setPhase(prev => (prev < 1 ? 1 : prev));
+      }
+    }, 1500);
+
+    void run();
+
+    return () => {
+      mounted = false;
+      clearTimeout(step0Timer);
+    };
+  }, [formData, recaptchaToken, attemptKey]);
+
+  const progressPct = phase === 0 ? 10 : phase === 1 ? 45 : phase === 2 ? 85 : 100;
+
+  const handleRetry = () => {
+    setError(null);
+    setPhase(0);
+    setAttemptKey(k => k + 1);
+  };
+
+  const handleReturnToForm = () => {
+    if (error?.kind === 'validation_error') {
+      onReturnToForm(error.errors);
+    } else {
+      onReturnToForm();
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-page-bg">
+      {/* ── Navbar ─────────────────────────────────────────────────────────── */}
+      <nav className="flex items-center justify-between border-b border-card-border bg-white px-6 py-4">
+        <div className="flex items-center gap-2">
+          <div className="flex size-8 items-center justify-center rounded-md bg-accent-blue">
+            <span className="text-sm font-bold text-white">E3</span>
+          </div>
+          <span className="text-sm font-semibold text-text-primary">E3 Digital</span>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-full border border-card-border bg-page-bg px-3 py-1.5">
+          <span
+            className="inline-block size-2 rounded-full bg-accent-blue"
+            style={{ animation: 'pulse 1.5s ease-in-out infinite' }}
+            aria-hidden="true"
+          />
+          <span className="text-xs font-medium uppercase tracking-wider text-text-muted">
+            STATUS
+          </span>
+          <span className="text-xs font-semibold text-text-secondary">
+            {error ? 'Error' : phase < 3 ? 'Processing' : 'Complete'}
+          </span>
+        </div>
+      </nav>
+
+      {/* ── Main content ───────────────────────────────────────────────────── */}
+      <main className="flex min-h-[calc(100vh-65px)] flex-col items-center justify-center px-4 py-12">
+        {error
+          ? (
+              <div className="w-full max-w-[480px]">
+                <ErrorCard
+                  error={error}
+                  onRetry={handleRetry}
+                  onReturnToForm={handleReturnToForm}
+                />
+              </div>
+            )
+          : (
+              <div className="w-full max-w-[480px] rounded-xl border border-card-border bg-white p-8 shadow-card">
+                {/* Spinning progress indicator */}
+                <div className="mb-6 flex justify-center">
+                  <svg
+                    width="64"
+                    height="64"
+                    viewBox="0 0 64 64"
+                    fill="none"
+                    className="animate-spin"
+                    aria-label="Processing your assessment"
+                  >
+                    <circle cx="32" cy="32" r="28" stroke="#e2e8f0" strokeWidth="5" />
+                    <path
+                      d="M 32 4 A 28 28 0 0 1 60 32"
+                      stroke="#2563eb"
+                      strokeWidth="5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </div>
+
+                {/* Heading */}
+                <h1 className="mb-2 text-center text-xl font-semibold text-text-primary">
+                  Preparing your personalised report...
+                </h1>
+                <p className="mb-8 text-center text-sm text-text-secondary">
+                  Our AI is analysing your responses against investor readiness criteria.
+                  {' '}
+                  This usually takes 15–30 seconds.
+                </p>
+
+                {/* Step timeline */}
+                <div className="relative mb-8">
+                  {/* Connecting track line behind the circles */}
+                  <div
+                    className="absolute left-4 top-4 w-0.5 bg-card-border"
+                    style={{ height: 'calc(100% - 2rem)' }}
+                    aria-hidden="true"
+                  />
+
+                  <div className="space-y-6">
+                    {STEPS.map((step, index) => (
+                      <StepItem
+                        key={step}
+                        label={step}
+                        status={getStepStatus(index, phase)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Progress bar */}
+                <div
+                  className="h-2 overflow-hidden rounded-full bg-card-border"
+                  role="progressbar"
+                  aria-valuenow={progressPct}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <div
+                    className="h-2 rounded-full bg-accent-blue transition-all duration-700"
+                    style={{ width: `${progressPct}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+        {/* Footer */}
+        <p className="mt-8 text-xs uppercase tracking-wider text-text-muted">
+          Powered by E3 Digital
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/ai/scoring.ts
+++ b/src/lib/ai/scoring.ts
@@ -1,0 +1,297 @@
+import { z } from 'zod';
+
+import type { AssessmentResponses } from '@/lib/validation/submission-schema';
+import { Env } from '@/libs/Env';
+
+// ── Zod schema for the expected AI response ──────────────────────────────────
+
+const CategorySchema = z.object({
+  name: z.string(),
+  score: z.number().min(0).max(100),
+  justification: z.string(),
+  recommendation: z.string(),
+});
+
+const GapSchema = z.object({
+  title: z.string(),
+  currentState: z.string(),
+  recommendedActions: z.array(z.string()),
+});
+
+export const AIScoringResponseSchema = z.object({
+  overallScore: z.number().min(0).max(100),
+  readinessLevel: z.enum(['investment_ready', 'nearly_there', 'early_stage', 'too_early']),
+  categories: z.array(CategorySchema).length(10),
+  topGaps: z.array(GapSchema).min(1).max(3),
+  quickWins: z.array(z.string()).min(1).max(5),
+  mediumTermRecommendations: z.array(z.string()).min(1).max(5),
+});
+
+export type AIScoringResponse = z.infer<typeof AIScoringResponseSchema>;
+
+// ── Prompt construction ───────────────────────────────────────────────────────
+
+function formatResponses(data: AssessmentResponses): string {
+  const lines: string[] = [];
+
+  lines.push('SECTION 1: Problem-Market Fit');
+  lines.push(`  Problem Clarity: ${data.problemClarity}`);
+  lines.push(`  Target Customer: ${data.targetCustomer}`);
+  lines.push(`  Market Size: ${data.marketSize}`);
+  lines.push(`  Competitor Awareness: ${data.competitorAwareness}`);
+  lines.push(`  Unique Advantage: ${data.uniqueAdvantage}`);
+
+  lines.push('\nSECTION 2: Product & Traction');
+  lines.push(`  Product Stage: ${data.productStage}`);
+  lines.push(`  Has Paying Customers: ${data.hasPayingCustomers}`);
+  if (data.currentMRR) {
+    lines.push(`  Current MRR/ARR (£): ${data.currentMRR}`);
+  }
+  if (data.customerGrowthRate) {
+    lines.push(`  Customer Growth Rate: ${data.customerGrowthRate}`);
+  }
+  lines.push(`  Evidence of Demand: ${data.evidenceOfDemand.join(', ')}`);
+
+  lines.push('\nSECTION 3: Business Model');
+  lines.push(`  Revenue Model Clarity: ${data.revenueModelClarity}`);
+  lines.push(`  Primary Revenue Model: ${data.primaryRevenueModel}`);
+  lines.push(`  Unit Economics Knowledge: ${data.unitEconomics}`);
+  lines.push(`  Pricing Confidence: ${data.pricingConfidence}`);
+
+  lines.push('\nSECTION 4: Team');
+  lines.push(`  Co-founder Count: ${data.coFounderCount}`);
+  lines.push(`  Team Coverage (skills): ${data.teamCoverage}`);
+  lines.push(`  Founder Experience: ${data.founderExperience}`);
+  lines.push(`  Full-time Team Size: ${data.fullTimeTeamSize}`);
+
+  lines.push('\nSECTION 5: Financials');
+  lines.push(`  Financial Model: ${data.financialModel}`);
+  lines.push(`  Monthly Burn Rate (£): ${data.monthlyBurnRate}`);
+  lines.push(`  Runway: ${data.runwayMonths}`);
+  lines.push(`  Prior Funding: ${data.priorFunding}`);
+
+  lines.push('\nSECTION 6: Go-to-Market');
+  lines.push(`  GTM Strategy: ${data.gtmStrategy}`);
+  lines.push(`  Acquisition Channels: ${data.acquisitionChannels.join(', ')}`);
+  lines.push(`  CAC Knowledge: ${data.cacKnowledge}`);
+  lines.push(`  Sales Repeatability: ${data.salesRepeatability}`);
+
+  lines.push('\nSECTION 7: Legal & IP');
+  lines.push(`  Company Incorporation: ${data.companyIncorporation}`);
+  lines.push(`  IP Protection: ${data.ipProtection.join(', ')}`);
+  lines.push(`  Key Agreements in Place: ${data.keyAgreements}`);
+
+  lines.push('\nSECTION 8: Investment Readiness');
+  lines.push(`  Has Pitch Deck: ${data.hasPitchDeck}`);
+  lines.push(`  Funding Ask Clarity: ${data.fundingAskClarity}`);
+  lines.push(`  Target Investment Stage: ${data.investmentStage}`);
+  lines.push(`  Investor Conversations: ${data.investorConversations}`);
+
+  lines.push('\nSECTION 9: Metrics & Data');
+  lines.push(`  Tracking Maturity: ${data.trackingMetrics}`);
+  lines.push(`  Metrics Tracked: ${data.metricsTracked.join(', ')}`);
+  lines.push(`  Can Demonstrate Growth: ${data.canDemonstrateGrowth}`);
+
+  lines.push('\nSECTION 10: Vision & Scalability');
+  lines.push(`  Vision Scale: ${data.visionScale}`);
+  lines.push(`  Scalability Strategy: ${data.scalabilityStrategy}`);
+  lines.push(`  Biggest Risks: ${data.biggestRisks}`);
+
+  return lines.join('\n');
+}
+
+function buildSystemPrompt(): string {
+  return `You are an experienced startup investment analyst with deep expertise in B2B SaaS ventures. \
+Your task is to evaluate a founder's investor readiness based on their self-assessment responses.
+
+Score each of the following 10 categories from 0 to 100:
+1. Problem-Market Fit — clarity of problem, target customer definition, market size, competitive differentiation
+2. Product & Traction — product stage, customer validation, evidence of demand, growth indicators
+3. Business Model — revenue model clarity, pricing confidence, unit economics understanding
+4. Team — founder experience, team completeness, domain expertise, full-time commitment
+5. Financials — financial model sophistication, burn rate awareness, runway, prior funding
+6. Go-to-Market — GTM strategy clarity, acquisition channels, CAC awareness, sales repeatability
+7. Legal & IP — incorporation status, IP protection, key agreements in place
+8. Investment Readiness — pitch deck existence, funding ask clarity, investor engagement level
+9. Metrics & Data — tracking maturity, key metrics coverage, ability to demonstrate growth
+10. Vision & Scalability — scale of vision, scalability strategy, risk awareness
+
+Scoring guide:
+- 80–100: Excellent — investor-ready for this category
+- 60–79: Good — minor gaps exist
+- 40–59: Developing — notable gaps
+- 20–39: Early stage — significant gaps
+- 0–19: Pre-early — not investment-ready in this area
+
+Readiness level thresholds (based on overall weighted score):
+- investment_ready: 70–100
+- nearly_there: 50–69
+- early_stage: 25–49
+- too_early: 0–24
+
+IMPORTANT: Respond ONLY with a single valid JSON object. No markdown fences, no explanation, no preamble. \
+The JSON must exactly match this structure:
+{
+  "overallScore": <0-100>,
+  "readinessLevel": "<investment_ready|nearly_there|early_stage|too_early>",
+  "categories": [
+    { "name": "<category name>", "score": <0-100>, "justification": "<1-2 sentences>", "recommendation": "<specific action>" }
+    // exactly 10 entries, one per category in order
+  ],
+  "topGaps": [
+    { "title": "<gap title>", "currentState": "<current weakness>", "recommendedActions": ["<action>", "<action>"] }
+    // 1–3 most critical gaps
+  ],
+  "quickWins": ["<actionable item doable this week>", ...],
+  "mediumTermRecommendations": ["<1–3 month strategic recommendation>", ...]
+}`;
+}
+
+// ── OpenRouter API call ───────────────────────────────────────────────────────
+
+type OpenRouterMessage = {
+  role: 'system' | 'user';
+  content: string;
+};
+
+type OpenRouterRequest = {
+  model: string;
+  messages: OpenRouterMessage[];
+  temperature: number;
+  response_format: { type: 'json_object' };
+};
+
+type OpenRouterResponseBody = {
+  choices: Array<{
+    message: { content: string };
+  }>;
+};
+
+const AI_MODEL = process.env.AI_MODEL ?? 'anthropic/claude-sonnet-4';
+const TIMEOUT_MS = 30_000;
+
+async function callOpenRouter(messages: OpenRouterMessage[]): Promise<string> {
+  const apiKey = Env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENROUTER_API_KEY is not configured');
+  }
+
+  const body: OpenRouterRequest = {
+    model: AI_MODEL,
+    messages,
+    temperature: 0.3,
+    response_format: { type: 'json_object' },
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.NEXT_PUBLIC_APP_URL ?? 'https://assess.e3digital.net',
+        'X-Title': 'E3 Digital Investor Readiness Assessment',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`OpenRouter API error ${response.status}: ${text}`);
+    }
+
+    const data = await response.json() as OpenRouterResponseBody;
+    const content = data.choices[0]?.message.content;
+    if (!content) {
+      throw new Error('OpenRouter returned empty content');
+    }
+    return content;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── JSON parsing (handles markdown fences if model ignores response_format) ──
+
+function parseJsonContent(content: string): unknown {
+  let text = content.trim();
+  // Strip markdown code fences (```json ... ``` or ``` ... ```) if present
+  if (text.startsWith('```')) {
+    const firstNewline = text.indexOf('\n');
+    if (firstNewline !== -1) {
+      text = text.slice(firstNewline + 1);
+    }
+    const lastFence = text.lastIndexOf('```');
+    if (lastFence !== -1) {
+      text = text.slice(0, lastFence).trimEnd();
+    }
+  }
+  return JSON.parse(text);
+}
+
+// ── Public scoring function ───────────────────────────────────────────────────
+
+/**
+ * Score an assessment using OpenRouter AI.
+ * Retries once with a correction prompt if the first response fails Zod validation.
+ * Throws on second failure — caller should handle the fallback.
+ */
+export async function scoreAssessment(responses: AssessmentResponses): Promise<AIScoringResponse> {
+  const systemPrompt = buildSystemPrompt();
+  const userContent = `Please evaluate the following founder assessment responses:\n\n${formatResponses(responses)}`;
+
+  const messages: OpenRouterMessage[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userContent },
+  ];
+
+  // First attempt
+  const firstContent = await callOpenRouter(messages);
+
+  let parsed: unknown;
+  try {
+    parsed = parseJsonContent(firstContent);
+  } catch {
+    parsed = null;
+  }
+
+  const firstResult = AIScoringResponseSchema.safeParse(parsed);
+  if (firstResult.success) {
+    return firstResult.data;
+  }
+
+  // Second attempt — send correction prompt with the invalid response
+  const correctionMessages: OpenRouterMessage[] = [
+    ...messages,
+    { role: 'user', content: firstContent },
+    {
+      role: 'user',
+      content:
+        `Your previous response did not match the required JSON schema. \
+Validation errors: ${JSON.stringify(firstResult.error.issues)}. \
+Please respond ONLY with a corrected JSON object matching the exact schema specified in the system prompt.`,
+    },
+  ];
+
+  const secondContent = await callOpenRouter(correctionMessages);
+
+  let parsed2: unknown;
+  try {
+    parsed2 = parseJsonContent(secondContent);
+  } catch {
+    parsed2 = null;
+  }
+
+  const secondResult = AIScoringResponseSchema.safeParse(parsed2);
+  if (secondResult.success) {
+    return secondResult.data;
+  }
+
+  throw new Error(
+    `AI response failed validation after retry: ${JSON.stringify(secondResult.error.issues)}`,
+  );
+}

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Hash an IP address with SHA-256 before storing.
+ * We never store raw IPs — only hashed representations.
+ */
+export function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex');
+}

--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -1,0 +1,62 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { rateLimits } from '@/models/Schema';
+
+const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const MAX_REQUESTS = 3;
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfter: number };
+
+/**
+ * Check whether the given (ipHash, action) pair has exceeded the rate limit.
+ * Uses a fixed 1-hour window keyed on the floored hour.
+ *
+ * If under the limit, increments the counter and returns { allowed: true }.
+ * If over the limit, returns { allowed: false, retryAfter } (seconds until window resets).
+ */
+export async function checkRateLimit(
+  ipHash: string,
+  action: string,
+): Promise<RateLimitResult> {
+  const now = new Date();
+  // Floor to the current hour boundary
+  const windowStart = new Date(Math.floor(now.getTime() / WINDOW_MS) * WINDOW_MS);
+  const windowEnd = new Date(windowStart.getTime() + WINDOW_MS);
+
+  const existing = await db
+    .select()
+    .from(rateLimits)
+    .where(
+      and(
+        eq(rateLimits.ipHash, ipHash),
+        eq(rateLimits.action, action),
+        eq(rateLimits.windowStart, windowStart),
+      ),
+    )
+    .limit(1);
+
+  const current = existing[0];
+
+  if (current && current.count >= MAX_REQUESTS) {
+    const retryAfter = Math.ceil((windowEnd.getTime() - now.getTime()) / 1000);
+    return { allowed: false, retryAfter };
+  }
+
+  if (current) {
+    await db
+      .update(rateLimits)
+      .set({ count: current.count + 1 })
+      .where(eq(rateLimits.id, current.id));
+  } else {
+    await db.insert(rateLimits).values({
+      ipHash,
+      action,
+      windowStart,
+    });
+  }
+
+  return { allowed: true };
+}

--- a/src/lib/recaptcha.ts
+++ b/src/lib/recaptcha.ts
@@ -1,0 +1,77 @@
+// ── Client-side reCAPTCHA v3 helpers ─────────────────────────────────────────
+// Call these only from 'use client' components.
+
+type GrecaptchaInstance = {
+  ready: (callback: () => void) => void;
+  execute: (siteKey: string, options: { action: string }) => Promise<string>;
+};
+
+/**
+ * Append the reCAPTCHA v3 script to <head> if not already present.
+ * Safe to call multiple times — idempotent.
+ */
+export function loadRecaptchaScript(siteKey: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (document.querySelector('#recaptcha-script')) {
+    return;
+  }
+  const script = document.createElement('script');
+  script.id = 'recaptcha-script';
+  script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+  script.async = true;
+  document.head.appendChild(script);
+}
+
+/**
+ * Generate an invisible reCAPTCHA v3 token for the given action.
+ * Returns an empty string if the script is not yet loaded or window is unavailable.
+ */
+export async function getRecaptchaToken(siteKey: string, action: string): Promise<string> {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  const w = window as Window & { grecaptcha?: GrecaptchaInstance };
+  if (!w.grecaptcha) {
+    return '';
+  }
+  return new Promise<string>((resolve) => {
+    w.grecaptcha!.ready(() => {
+      w.grecaptcha!.execute(siteKey, { action }).then(resolve).catch(() => resolve(''));
+    });
+  });
+}
+
+// ── Server-side reCAPTCHA verification ────────────────────────────────────────
+// Call this only from API routes / server actions.
+
+type RecaptchaVerifyResponse = {
+  'success': boolean;
+  'score'?: number;
+  'action'?: string;
+  'error-codes'?: string[];
+};
+
+/**
+ * Verify a reCAPTCHA v3 token with Google's siteverify API.
+ * Returns { success: false, score: null } on network failure (fail-open for graceful degradation).
+ */
+export async function verifyRecaptchaToken(
+  token: string,
+  secretKey: string,
+): Promise<{ success: boolean; score: number | null }> {
+  try {
+    const params = new URLSearchParams({ secret: secretKey, response: token });
+    const res = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+    const data = await res.json() as RecaptchaVerifyResponse;
+    return { success: data.success, score: data.score ?? null };
+  } catch {
+    // Network failure — fail-open: let submission proceed rather than block users
+    return { success: true, score: null };
+  }
+}

--- a/src/lib/validation/submission-schema.ts
+++ b/src/lib/validation/submission-schema.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+/**
+ * Server-side Zod schema for the full assessment response payload.
+ * Mirrors AssessmentFormData — re-validates on the server even after client validation.
+ * Conditional fields (currentMRR, customerGrowthRate) are optional here;
+ * client-side already enforced them when relevant.
+ */
+export const AssessmentResponsesSchema = z.object({
+  // Section 1: Problem-Market Fit
+  problemClarity: z.string().min(1),
+  targetCustomer: z.string().min(1),
+  marketSize: z.string().min(1),
+  competitorAwareness: z.string().min(1),
+  uniqueAdvantage: z.string().min(1),
+  // Section 2: Product & Traction
+  productStage: z.string().min(1),
+  hasPayingCustomers: z.string().min(1),
+  currentMRR: z.string().optional(),
+  customerGrowthRate: z.string().optional(),
+  evidenceOfDemand: z.array(z.string()).min(1),
+  // Section 3: Business Model
+  revenueModelClarity: z.string().min(1),
+  primaryRevenueModel: z.string().min(1),
+  unitEconomics: z.string().min(1),
+  pricingConfidence: z.string().min(1),
+  // Section 4: Team
+  coFounderCount: z.string().min(1),
+  teamCoverage: z.string().min(1),
+  founderExperience: z.string().min(1),
+  fullTimeTeamSize: z.string().min(1),
+  // Section 5: Financials
+  financialModel: z.string().min(1),
+  monthlyBurnRate: z.string().min(1),
+  runwayMonths: z.string().min(1),
+  priorFunding: z.string().min(1),
+  // Section 6: Go-to-Market
+  gtmStrategy: z.string().min(1),
+  acquisitionChannels: z.array(z.string()).min(1),
+  cacKnowledge: z.string().min(1),
+  salesRepeatability: z.string().min(1),
+  // Section 7: Legal & IP
+  companyIncorporation: z.string().min(1),
+  ipProtection: z.array(z.string()).min(1),
+  keyAgreements: z.string().min(1),
+  // Section 8: Investment Readiness
+  hasPitchDeck: z.string().min(1),
+  fundingAskClarity: z.string().min(1),
+  investmentStage: z.string().min(1),
+  investorConversations: z.string().min(1),
+  // Section 9: Metrics & Data
+  trackingMetrics: z.string().min(1),
+  metricsTracked: z.array(z.string()).min(1),
+  canDemonstrateGrowth: z.string().min(1),
+  // Section 10: Vision & Scalability
+  visionScale: z.string().min(1),
+  scalabilityStrategy: z.string().min(1),
+  biggestRisks: z.string().min(1),
+  // Section 11: Contact Info
+  contactName: z.string().min(1),
+  contactEmail: z.string().email(),
+  contactCompany: z.string().optional(),
+  contactLinkedin: z.string().optional(),
+  contactSource: z.string().optional(),
+  consentChecked: z.literal(true, {
+    errorMap: () => ({ message: 'Consent is required' }),
+  }),
+});
+
+export const SubmissionBodySchema = z.object({
+  responses: AssessmentResponsesSchema,
+  recaptchaToken: z.string(),
+});
+
+export type SubmissionBody = z.infer<typeof SubmissionBodySchema>;
+export type AssessmentResponses = z.infer<typeof AssessmentResponsesSchema>;

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -18,6 +18,7 @@ export const Env = createEnv({
     BREVO_API_KEY: z.string().optional(),
     // AI Scoring
     OPENROUTER_API_KEY: z.string().optional(),
+    AI_MODEL: z.string().optional(),
     // Bot prevention
     RECAPTCHA_SECRET_KEY: z.string().optional(),
   },
@@ -51,6 +52,7 @@ export const Env = createEnv({
     MAILGUN_DOMAIN: process.env.MAILGUN_DOMAIN,
     BREVO_API_KEY: process.env.BREVO_API_KEY,
     OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    AI_MODEL: process.env.AI_MODEL,
     RECAPTCHA_SECRET_KEY: process.env.RECAPTCHA_SECRET_KEY,
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     NEXT_PUBLIC_CLERK_SIGN_IN_URL: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,


### PR DESCRIPTION
## Summary

- **POST /api/assessment/submit** — rate limit → reCAPTCHA verify → Zod validate → DB insert → AI score → redirect URL
- **Rate limiting** — 3 submissions/hour/IP using SHA-256 hashed IP + `rate_limits` table
- **reCAPTCHA v3** — client script loader + Google siteverify; gracefully skipped when keys not configured
- **OpenRouter AI scoring** — `anthropic/claude-sonnet-4`, temp 0.3, strict JSON response, Zod validation, retry
  once on schema failure, fallback to manual review (`ai_scored: false`) on second failure
- **Processing animation** — Stitch-spec 3-step timeline (Analyzing → Scoring → Generating), progress bar,
  error states with retry/return-to-form actions
- **AssessmentForm wired** — real API call replaces `/results/sample` placeholder; reCAPTCHA token generated on
  submit; ProcessingScreen takes over viewport

## Test plan

- [ ] Submit full assessment → see processing animation → redirect to `/results/<uuid>`
- [ ] Submit 4 times from same IP within 1 hour → 4th blocked with rate limit message
- [ ] Disconnect internet before submit → network error state + Retry button
- [ ] Add `OPENROUTER_API_KEY` to `.env.local` and verify AI scores are saved to DB
- [ ] Without `OPENROUTER_API_KEY` → assessment saved with `ai_scored: false`
- [ ] `npm run build && npm run lint && npm run check-types && npm run test` all pass

## Semgrep

1 pre-existing finding: `src/libs/DB.ts` line 18 — `rejectUnauthorized: false` for Railway SSL
(carried over from Phase 0, not introduced in Phase 3).

## Env vars to add to `.env.local`

```
OPENROUTER_API_KEY=<your key>
AI_MODEL=anthropic/claude-sonnet-4   # optional, defaults to this value
```

reCAPTCHA keys left as placeholders — configure before production launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)