### PR TITLE
feat(email): phase 5 — mailgun email delivery

### DIFF
--- a/src/app/api/webhooks/mailgun/route.ts
+++ b/src/app/api/webhooks/mailgun/route.ts
@@ -1,0 +1,137 @@
+import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
+
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db } from '@/libs/DB';
+import { Env } from '@/libs/Env';
+import { assessments, emailLogs } from '@/models/Schema';
+
+export const dynamic = 'force-dynamic';
+
+// ── Webhook payload types ────────────────────────────────────────────────────
+type MailgunSignature = {
+  timestamp: string;
+  token: string;
+  signature: string;
+};
+
+type MailgunDeliveryStatus = {
+  message?: string;
+  description?: string;
+};
+
+type MailgunEventData = {
+  'event': string;
+  'message': {
+    headers: {
+      'message-id': string;
+    };
+  };
+  'timestamp': number;
+  'delivery-status'?: MailgunDeliveryStatus;
+};
+
+type MailgunWebhookPayload = {
+  'signature': MailgunSignature;
+  'event-data': MailgunEventData;
+};
+
+// ── POST handler ─────────────────────────────────────────────────────────────
+export async function POST(request: Request): Promise<NextResponse> {
+  let payload: MailgunWebhookPayload;
+
+  try {
+    payload = await request.json() as MailgunWebhookPayload;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { signature, 'event-data': eventData } = payload;
+
+  // ── Signature verification ─────────────────────────────────────────────────
+  const signingKey = Env.MAILGUN_WEBHOOK_SIGNING_KEY;
+
+  if (signingKey) {
+    const { timestamp, token, signature: providedSig } = signature;
+    const computed = crypto
+      .createHmac('sha256', signingKey)
+      .update(timestamp + token)
+      .digest('hex');
+
+    let valid = false;
+    try {
+      valid = crypto.timingSafeEqual(
+        Buffer.from(computed, 'hex'),
+        Buffer.from(providedSig, 'hex'),
+      );
+    } catch {
+      valid = false;
+    }
+
+    if (!valid) {
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+  }
+
+  // ── Extract event details ──────────────────────────────────────────────────
+  const event = eventData.event;
+  const rawMessageId = eventData.message.headers['message-id'] ?? '';
+  // Strip angle brackets that may wrap the ID
+  const messageId = rawMessageId.replace(/^<|>$/g, '');
+
+  // ── Look up email_logs record ──────────────────────────────────────────────
+  const logs = await db
+    .select()
+    .from(emailLogs)
+    .where(eq(emailLogs.messageId, messageId))
+    .limit(1);
+
+  const log = logs[0];
+  if (!log) {
+    // Idempotent — unknown message IDs are not an error
+    return NextResponse.json({ ok: true });
+  }
+
+  const eventTime = new Date(eventData.timestamp * 1000);
+
+  // ── Handle each event type ──────────────────────────────────────────────────
+  if (event === 'delivered') {
+    await db
+      .update(emailLogs)
+      .set({ status: 'delivered', deliveredAt: eventTime })
+      .where(eq(emailLogs.id, log.id));
+
+    // Mirror emailSent flag on assessment
+    await db
+      .update(assessments)
+      .set({ emailSent: true })
+      .where(eq(assessments.id, log.assessmentId));
+  } else if (event === 'opened') {
+    await db
+      .update(emailLogs)
+      .set({ status: 'opened', openedAt: eventTime })
+      .where(eq(emailLogs.id, log.id));
+  } else if (event === 'clicked') {
+    await db
+      .update(emailLogs)
+      .set({ status: 'clicked', clickedAt: eventTime })
+      .where(eq(emailLogs.id, log.id));
+  } else if (event === 'failed') {
+    const deliveryStatus = eventData['delivery-status'];
+    const failureReason = deliveryStatus?.message ?? deliveryStatus?.description ?? 'Unknown failure';
+
+    await db
+      .update(emailLogs)
+      .set({ status: 'failed', failedAt: eventTime, failureReason })
+      .where(eq(emailLogs.id, log.id));
+  } else if (event === 'complained') {
+    await db
+      .update(emailLogs)
+      .set({ status: 'bounced', failedAt: eventTime, failureReason: 'Spam complaint' })
+      .where(eq(emailLogs.id, log.id));
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/email/mailgun.ts
+++ b/src/lib/email/mailgun.ts
@@ -1,0 +1,61 @@
+import { Buffer } from 'node:buffer';
+
+import { Env } from '@/libs/Env';
+
+export type MailgunSendParams = {
+  to: string;
+  subject: string;
+  html: string;
+  recipientVariables?: Record<string, unknown>;
+};
+
+export type MailgunSendResult =
+  | { success: true; messageId: string }
+  | { success: false; status: number; body: string };
+
+export async function sendViaMailgun(params: MailgunSendParams): Promise<MailgunSendResult> {
+  const apiKey = Env.MAILGUN_API_KEY;
+  const domain = Env.MAILGUN_DOMAIN;
+
+  if (!apiKey || !domain) {
+    return { success: false, status: 0, body: 'Mailgun not configured' };
+  }
+
+  const { to, subject, html, recipientVariables } = params;
+
+  const formData = new URLSearchParams();
+  formData.set('from', 'E3 Digital <info@e3digital.net>');
+  formData.set('h:Reply-To', 'razaq@e3.digital');
+  formData.set('to', to);
+  formData.set('subject', subject);
+  formData.set('html', html);
+
+  if (recipientVariables) {
+    formData.set('recipient-variables', JSON.stringify(recipientVariables));
+  }
+
+  const credentials = Buffer.from(`api:${apiKey}`).toString('base64');
+
+  let response: Response;
+  try {
+    response = await fetch(`https://api.eu.mailgun.net/v3/${domain}/messages`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: formData.toString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, status: 0, body: message };
+  }
+
+  if (response.ok) {
+    const json = await response.json() as { id: string; message: string };
+    return { success: true, messageId: json.id };
+  }
+
+  const body = await response.text();
+  return { success: false, status: response.status, body };
+}

--- a/src/lib/email/retry.ts
+++ b/src/lib/email/retry.ts
@@ -1,0 +1,142 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { assessments, emailLogs } from '@/models/Schema';
+
+import { sendViaMailgun } from './mailgun';
+import { type AssessmentEmailData, buildAssessmentResultsEmail } from './templates/assessment-results';
+
+// ── Readiness label map ──────────────────────────────────────────────────────
+const READINESS_LABELS: Record<string, string> = {
+  investment_ready: 'Investment Ready',
+  nearly_there: 'Nearly There',
+  early_stage: 'Early Stage',
+  too_early: 'Too Early',
+};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+export type SendAssessmentEmailParams = {
+  assessmentId: string;
+  recipientEmail: string;
+  contactName: string;
+  contactCompany?: string;
+  overallScore: number;
+  readinessLevel: 'investment_ready' | 'nearly_there' | 'early_stage' | 'too_early';
+  categoryScores: Array<{ name: string; score: number }>;
+  topGaps: Array<{ title: string; currentState: string; recommendedActions: string[] }>;
+  quickWins: string[];
+  resultsUrl: string;
+  bookingUrl: string;
+};
+
+// ── Main send function (fire-and-forget safe) ────────────────────────────────
+export async function sendAssessmentEmailWithRetry(
+  params: SendAssessmentEmailParams,
+): Promise<void> {
+  const {
+    assessmentId,
+    recipientEmail,
+    contactName,
+    contactCompany,
+    overallScore,
+    readinessLevel,
+    categoryScores,
+    topGaps,
+    quickWins,
+    resultsUrl,
+    bookingUrl,
+  } = params;
+
+  try {
+    const readinessLabel = READINESS_LABELS[readinessLevel] ?? readinessLevel;
+    const subject = `Your Investor Readiness Score: ${overallScore}/100 — ${readinessLabel}`;
+
+    const emailData: AssessmentEmailData = {
+      contactName,
+      contactCompany,
+      overallScore,
+      readinessLevel,
+      categoryScores,
+      topGaps,
+      quickWins,
+      resultsUrl,
+      bookingUrl,
+      unsubscribeUrl: `${resultsUrl}?unsubscribe=1`,
+    };
+
+    const html = buildAssessmentResultsEmail(emailData);
+
+    // Create email_logs record with status 'pending'
+    const logResult = await db
+      .insert(emailLogs)
+      .values({
+        assessmentId,
+        status: 'pending',
+        subject,
+        recipientEmail,
+      })
+      .returning({ id: emailLogs.id });
+
+    const logId = logResult[0]?.id;
+    if (logId === undefined) {
+      console.error('[email/retry] Failed to create email_logs record for assessment:', assessmentId);
+      return;
+    }
+
+    // Retry loop: 3 attempts, delays = [0, 5000, 30000] ms
+    const delays = [0, 5000, 30000];
+    let lastFailureReason = '';
+
+    for (let attempt = 0; attempt < delays.length; attempt++) {
+      const delay = delays[attempt] ?? 0;
+
+      // Skip delay on first attempt
+      if (attempt > 0) {
+        await new Promise<void>(r => setTimeout(r, delay));
+      }
+
+      const result = await sendViaMailgun({ to: recipientEmail, subject, html });
+
+      if (result.success) {
+        // Update email_log: sent
+        await db
+          .update(emailLogs)
+          .set({
+            status: 'sent',
+            messageId: result.messageId,
+            sentAt: new Date(),
+            retryCount: attempt,
+          })
+          .where(eq(emailLogs.id, logId));
+
+        // Update assessments.emailSent = true
+        await db
+          .update(assessments)
+          .set({ emailSent: true })
+          .where(eq(assessments.id, assessmentId));
+
+        return;
+      }
+
+      lastFailureReason = result.body;
+
+      // Do not retry on 4xx client errors (only retry on network errors or 5xx)
+      if (result.status !== 0 && result.status < 500) {
+        break;
+      }
+    }
+
+    // All retries failed — update email_log: failed
+    await db
+      .update(emailLogs)
+      .set({
+        status: 'failed',
+        failedAt: new Date(),
+        failureReason: lastFailureReason,
+      })
+      .where(eq(emailLogs.id, logId));
+  } catch (err) {
+    // Never propagate errors to callers
+    console.error('[email/retry] Unexpected error for assessment:', assessmentId, err);
+  }
+}

--- a/src/lib/email/templates/assessment-results.ts
+++ b/src/lib/email/templates/assessment-results.ts
@@ -1,0 +1,315 @@
+// ── Design system color constants ───────────────────────────────────────────
+const COLORS = {
+  navy: '#0f172a',
+  accentBlue: '#2563eb',
+  ctaGreen: '#10b981',
+  scoreGreen: '#22c55e',
+  scoreBlue: '#3b82f6',
+  scoreOrange: '#f97316',
+  scoreRed: '#ef4444',
+  pageBg: '#f8fafc',
+  cardBorder: '#e2e8f0',
+  textSecondary: '#475569',
+  textMuted: '#94a3b8',
+  white: '#ffffff',
+} as const;
+
+// ── Readiness level display labels ──────────────────────────────────────────
+const READINESS_LABELS: Record<string, string> = {
+  investment_ready: 'Investment Ready',
+  nearly_there: 'Nearly There',
+  early_stage: 'Early Stage',
+  too_early: 'Too Early',
+};
+
+// ── Score colour helper ──────────────────────────────────────────────────────
+function scoreColor(score: number): string {
+  if (score >= 75) {
+    return COLORS.scoreGreen;
+  }
+  if (score >= 60) {
+    return COLORS.scoreBlue;
+  }
+  if (score >= 40) {
+    return COLORS.scoreOrange;
+  }
+  return COLORS.scoreRed;
+}
+
+// ── Score bar HTML ───────────────────────────────────────────────────────────
+function scoreBar(score: number): string {
+  const color = scoreColor(score);
+  const width = Math.max(4, score);
+  return `
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+      <tr>
+        <td style="background:${COLORS.cardBorder};border-radius:4px;height:8px;overflow:hidden;">
+          <table cellpadding="0" cellspacing="0" border="0" width="${width}%">
+            <tr>
+              <td style="background:${color};height:8px;border-radius:4px;">&nbsp;</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>`;
+}
+
+// ── Category row ─────────────────────────────────────────────────────────────
+function categoryRow(name: string, score: number): string {
+  return `
+    <tr>
+      <td style="padding:8px 0;">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+          <tr>
+            <td style="font-size:13px;color:${COLORS.navy};font-weight:600;padding-bottom:4px;">${name}</td>
+            <td align="right" style="font-size:13px;color:${scoreColor(score)};font-weight:700;padding-bottom:4px;">${score}/100</td>
+          </tr>
+          <tr>
+            <td colspan="2">${scoreBar(score)}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>`;
+}
+
+// ── Gap card ─────────────────────────────────────────────────────────────────
+function gapCard(title: string, currentState: string, firstAction: string): string {
+  return `
+    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom:12px;border:1px solid ${COLORS.cardBorder};border-radius:8px;overflow:hidden;">
+      <tr>
+        <td style="background:${COLORS.pageBg};padding:14px 16px;">
+          <p style="margin:0 0 6px;font-size:14px;font-weight:700;color:${COLORS.navy};">${title}</p>
+          <p style="margin:0 0 8px;font-size:13px;color:${COLORS.textSecondary};">${currentState}</p>
+          <p style="margin:0;font-size:13px;color:${COLORS.accentBlue};font-weight:600;">Action: ${firstAction}</p>
+        </td>
+      </tr>
+    </table>`;
+}
+
+// ── Quick win row ────────────────────────────────────────────────────────────
+function quickWinRow(win: string): string {
+  return `
+    <tr>
+      <td style="padding:6px 0;font-size:14px;color:${COLORS.textSecondary};">
+        <table cellpadding="0" cellspacing="0" border="0">
+          <tr>
+            <td style="padding-right:10px;color:${COLORS.ctaGreen};font-size:16px;vertical-align:top;">&#10003;</td>
+            <td style="vertical-align:top;">${win}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>`;
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+export type AssessmentEmailData = {
+  contactName: string;
+  contactCompany?: string;
+  overallScore: number;
+  readinessLevel: string;
+  categoryScores: Array<{ name: string; score: number }>;
+  topGaps: Array<{ title: string; currentState: string; recommendedActions: string[] }>;
+  quickWins: string[];
+  resultsUrl: string;
+  bookingUrl: string;
+  unsubscribeUrl: string;
+};
+
+// ── Main builder ─────────────────────────────────────────────────────────────
+export function buildAssessmentResultsEmail(data: AssessmentEmailData): string {
+  const {
+    contactName,
+    contactCompany,
+    overallScore,
+    readinessLevel,
+    categoryScores,
+    topGaps,
+    quickWins,
+    resultsUrl,
+    bookingUrl,
+    unsubscribeUrl,
+  } = data;
+
+  const firstName = contactName.split(' ')[0] ?? contactName;
+  const readinessLabel = READINESS_LABELS[readinessLevel] ?? readinessLevel;
+  const scoreCol = scoreColor(overallScore);
+
+  // Sort categories: highest first for "strongest", lowest first for "weakest"
+  const sorted = [...categoryScores].sort((a, b) => b.score - a.score);
+  const strongest = sorted.slice(0, 3);
+  const weakest = [...categoryScores].sort((a, b) => a.score - b.score).slice(0, 3);
+
+  const top3Gaps = topGaps.slice(0, 3);
+  const top3QuickWins = quickWins.slice(0, 3);
+
+  const strongestRows = strongest.map(c => categoryRow(c.name, c.score)).join('');
+  const weakestRows = weakest.map(c => categoryRow(c.name, c.score)).join('');
+  const gapCards = top3Gaps.map(g => gapCard(g.title, g.currentState, g.recommendedActions[0] ?? '')).join('');
+  const quickWinRows = top3QuickWins.map(w => quickWinRow(w)).join('');
+
+  const companyLine = contactCompany ? ` at ${contactCompany}` : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Investor Readiness Score — E3 Digital</title>
+</head>
+<body style="margin:0;padding:0;background:${COLORS.pageBg};font-family:Arial,Helvetica,sans-serif;">
+
+  <!-- Outer wrapper -->
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background:${COLORS.pageBg};padding:24px 0;">
+    <tr>
+      <td align="center">
+        <!-- Email container -->
+        <table cellpadding="0" cellspacing="0" border="0" width="600" style="max-width:600px;background:${COLORS.white};border-radius:12px;overflow:hidden;border:1px solid ${COLORS.cardBorder};">
+
+          <!-- ── HEADER ─────────────────────────────────────────────────── -->
+          <tr>
+            <td style="background:${COLORS.navy};padding:28px 32px;text-align:center;">
+              <p style="margin:0 0 4px;font-size:22px;font-weight:700;color:${COLORS.white};letter-spacing:-0.5px;">E3 Digital</p>
+              <p style="margin:0;font-size:13px;color:${COLORS.textMuted};">Investor Readiness Assessment</p>
+            </td>
+          </tr>
+
+          <!-- ── SCORE HERO ──────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:36px 32px 28px;text-align:center;background:${COLORS.white};">
+              <p style="margin:0 0 8px;font-size:16px;color:${COLORS.textSecondary};">Hi ${firstName}${companyLine},</p>
+              <p style="margin:0 0 24px;font-size:15px;color:${COLORS.textSecondary};">Here is your investor readiness assessment result:</p>
+
+              <!-- Score circle (table-based) -->
+              <table cellpadding="0" cellspacing="0" border="0" align="center" style="margin:0 auto 16px;">
+                <tr>
+                  <td style="width:120px;height:120px;border-radius:50%;background:${COLORS.pageBg};border:6px solid ${scoreCol};text-align:center;vertical-align:middle;">
+                    <p style="margin:0;font-size:42px;font-weight:700;color:${scoreCol};line-height:1;">${overallScore}</p>
+                    <p style="margin:0;font-size:13px;color:${COLORS.textMuted};">/ 100</p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Readiness badge -->
+              <table cellpadding="0" cellspacing="0" border="0" align="center" style="margin:0 auto;">
+                <tr>
+                  <td style="background:${scoreCol};border-radius:20px;padding:6px 20px;">
+                    <p style="margin:0;font-size:14px;font-weight:700;color:${COLORS.white};">${readinessLabel}</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- ── CATEGORY BREAKDOWN ──────────────────────────────────────── -->
+          <tr>
+            <td style="padding:0 32px 28px;">
+
+              <!-- Side-by-side table: Strongest | Weakest -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <!-- Strongest -->
+                  <td width="48%" valign="top" style="padding-right:8px;">
+                    <p style="margin:0 0 12px;font-size:14px;font-weight:700;color:${COLORS.navy};">Top Strengths</p>
+                    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                      ${strongestRows}
+                    </table>
+                  </td>
+
+                  <!-- Spacer -->
+                  <td width="4%" style="padding:0 4px;">&nbsp;</td>
+
+                  <!-- Weakest -->
+                  <td width="48%" valign="top" style="padding-left:8px;">
+                    <p style="margin:0 0 12px;font-size:14px;font-weight:700;color:${COLORS.navy};">Key Gaps</p>
+                    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                      ${weakestRows}
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+            </td>
+          </tr>
+
+          <!-- ── DIVIDER ─────────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:0 32px;"><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="border-top:1px solid ${COLORS.cardBorder};height:1px;">&nbsp;</td></tr></table></td>
+          </tr>
+
+          <!-- ── TOP 3 GAPS ──────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="margin:0 0 16px;font-size:16px;font-weight:700;color:${COLORS.navy};">Your Top Priority Gaps</p>
+              ${gapCards}
+            </td>
+          </tr>
+
+          <!-- ── DIVIDER ─────────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:0 32px;"><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="border-top:1px solid ${COLORS.cardBorder};height:1px;">&nbsp;</td></tr></table></td>
+          </tr>
+
+          <!-- ── QUICK WINS ──────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="margin:0 0 16px;font-size:16px;font-weight:700;color:${COLORS.navy};">Quick Wins to Start This Week</p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                ${quickWinRows}
+              </table>
+            </td>
+          </tr>
+
+          <!-- ── DIVIDER ─────────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:0 32px;"><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="border-top:1px solid ${COLORS.cardBorder};height:1px;">&nbsp;</td></tr></table></td>
+          </tr>
+
+          <!-- ── CTA BUTTONS ─────────────────────────────────────────────── -->
+          <tr>
+            <td style="padding:28px 32px;text-align:center;">
+              <p style="margin:0 0 20px;font-size:15px;color:${COLORS.textSecondary};">Ready to close your gaps and get investment-ready?</p>
+
+              <!-- Primary CTA -->
+              <table cellpadding="0" cellspacing="0" border="0" align="center" style="margin:0 auto 12px;">
+                <tr>
+                  <td style="background:${COLORS.accentBlue};border-radius:8px;">
+                    <a href="${resultsUrl}" style="display:block;padding:14px 32px;font-size:15px;font-weight:700;color:${COLORS.white};text-decoration:none;">View Full Results &rarr;</a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Secondary CTA -->
+              <table cellpadding="0" cellspacing="0" border="0" align="center" style="margin:0 auto;">
+                <tr>
+                  <td style="background:${COLORS.ctaGreen};border-radius:8px;">
+                    <a href="${bookingUrl}" style="display:block;padding:14px 32px;font-size:15px;font-weight:700;color:${COLORS.white};text-decoration:none;">Book a Free Strategy Call</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- ── FOOTER ──────────────────────────────────────────────────── -->
+          <tr>
+            <td style="background:${COLORS.pageBg};padding:20px 32px;border-top:1px solid ${COLORS.cardBorder};">
+              <p style="margin:0 0 6px;font-size:13px;color:${COLORS.textMuted};text-align:center;">
+                Questions? Reply to this email or contact us at
+                <a href="mailto:razaq@e3.digital" style="color:${COLORS.accentBlue};text-decoration:none;">razaq@e3.digital</a>
+              </p>
+              <p style="margin:0;font-size:12px;color:${COLORS.textMuted};text-align:center;">
+                E3 Digital &bull;
+                <a href="${unsubscribeUrl}" style="color:${COLORS.textMuted};text-decoration:underline;">Unsubscribe</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+        <!-- /Email container -->
+      </td>
+    </tr>
+  </table>
+  <!-- /Outer wrapper -->
+
+</body>
+</html>`;
+}

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -14,6 +14,7 @@ export const Env = createEnv({
     // Email
     MAILGUN_API_KEY: z.string().optional(),
     MAILGUN_DOMAIN: z.string().optional(),
+    MAILGUN_WEBHOOK_SIGNING_KEY: z.string().optional(),
     // CRM
     BREVO_API_KEY: z.string().optional(),
     // AI Scoring
@@ -50,6 +51,7 @@ export const Env = createEnv({
     SENTRY_PROJECT: process.env.SENTRY_PROJECT,
     MAILGUN_API_KEY: process.env.MAILGUN_API_KEY,
     MAILGUN_DOMAIN: process.env.MAILGUN_DOMAIN,
+    MAILGUN_WEBHOOK_SIGNING_KEY: process.env.MAILGUN_WEBHOOK_SIGNING_KEY,
     BREVO_API_KEY: process.env.BREVO_API_KEY,
     OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
     AI_MODEL: process.env.AI_MODEL,


### PR DESCRIPTION
## Summary
- HTML scorecard email template (inline CSS, table-based, 600px max-width) with score hero,
  top 3 strengths/weaknesses, gap cards, quick wins, and dual CTA buttons
- Mailgun send function targeting EU API endpoint with Basic auth and graceful no-op when
  env vars are absent
- 3-attempt retry logic (0 / 5s / 30s delays) backed by `email_logs` DB tracking;
  skips retries on 4xx errors, marks assessment `email_sent = true` on success
- Mailgun webhook handler (`/api/webhooks/mailgun`) verifying HMAC-SHA256 signatures with
  timing-safe compare; updates `email_logs` on delivered / opened / clicked / failed / complained
- `MAILGUN_WEBHOOK_SIGNING_KEY` added to `Env.ts` validation
- Fire-and-forget email dispatch wired into `/api/assessment/submit` after AI scoring

## Test plan
- [ ] Add `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, `MAILGUN_WEBHOOK_SIGNING_KEY` to `.env.local`
- [ ] Submit a test assessment end-to-end and confirm email arrives
- [ ] Check `email_logs` table for a `status = 'sent'` row with `message_id` populated
- [ ] Trigger a Mailgun test webhook event and confirm `email_logs` status updates
- [ ] Confirm results page still loads immediately (email never blocks redirect)
- [ ] Confirm build passes without Mailgun env vars (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)