### PR TITLE
feat(assessment): phase 9c — typeform animation polish

### DIFF
--- a/src/components/assessment/AssessmentForm.tsx
+++ b/src/components/assessment/AssessmentForm.tsx
@@ -28,7 +28,7 @@ type ProcessingData = {
   recaptchaToken: string;
 };
 
-function QuestionDispatcher({ question }: { question: QuestionDef }) {
+function QuestionDispatcher({ question, animationDelay }: { question: QuestionDef; animationDelay: number }) {
   switch (question.type) {
     case 'text':
       return (
@@ -39,6 +39,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           helpText={question.helpText}
           maxLength={question.maxLength}
           required={question.required}
+          animationDelay={animationDelay}
         />
       );
     case 'textarea':
@@ -50,6 +51,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           helpText={question.helpText}
           maxLength={question.maxLength}
           required={question.required}
+          animationDelay={animationDelay}
         />
       );
     case 'email':
@@ -60,6 +62,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           placeholder={question.placeholder}
           helpText={question.helpText}
           required={question.required}
+          animationDelay={animationDelay}
         />
       );
     case 'number':
@@ -73,6 +76,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           prefix={question.prefix}
           suffix={question.suffix}
           min={question.min}
+          animationDelay={animationDelay}
         />
       );
     case 'radio':
@@ -82,6 +86,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           label={question.label}
           options={question.options}
           helpText={question.helpText}
+          animationDelay={animationDelay}
         />
       );
     case 'multiselect':
@@ -91,6 +96,7 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           label={question.label}
           options={question.options}
           helpText={question.helpText}
+          animationDelay={animationDelay}
         />
       );
     case 'dropdown':
@@ -102,18 +108,19 @@ function QuestionDispatcher({ question }: { question: QuestionDef }) {
           placeholder={question.placeholder}
           helpText={question.helpText}
           required={question.required}
+          animationDelay={animationDelay}
         />
       );
     case 'checkbox':
-      return <ConsentCheckbox name={question.fieldName} />;
+      return <ConsentCheckbox name={question.fieldName} animationDelay={animationDelay} />;
     default:
       return null;
   }
 }
 
-function SectionRenderer({ sectionIndex }: { sectionIndex: number }) {
+function SectionRenderer({ sectionIndex, shakeKey }: { sectionIndex: number; shakeKey: number }) {
   // Hooks must be called before any early returns (Rules of Hooks)
-  const { watch } = useFormContext<AssessmentFormData>();
+  const { watch, formState: { errors } } = useFormContext<AssessmentFormData>();
   const hasPayingCustomers = watch('hasPayingCustomers');
 
   const section = assessmentSections[sectionIndex];
@@ -131,7 +138,7 @@ function SectionRenderer({ sectionIndex }: { sectionIndex: number }) {
       </div>
 
       <div className="space-y-8 rounded-xl border border-card-border bg-white p-6 md:p-8">
-        {section.questions.map((question) => {
+        {section.questions.map((question, index) => {
           if (question.conditional) {
             const watchedValue
               = question.conditional.fieldName === 'hasPayingCustomers'
@@ -142,11 +149,25 @@ function SectionRenderer({ sectionIndex }: { sectionIndex: number }) {
             }
           }
 
-          return <QuestionDispatcher key={question.fieldName} question={question} />;
+          const hasError = errors[question.fieldName] !== undefined;
+          const questionKey = hasError ? `${question.fieldName}-err-${shakeKey}` : question.fieldName;
+          const animationDelay = Math.min(index * 100, 500);
+
+          return (
+            <QuestionDispatcher
+              key={questionKey}
+              question={question}
+              animationDelay={animationDelay}
+            />
+          );
         })}
 
         {sectionIndex === assessmentSections.length - 1 && (
-          <ConsentCheckbox name="consentChecked" />
+          <ConsentCheckbox
+            key={errors.consentChecked !== undefined ? `consentChecked-err-${shakeKey}` : 'consentChecked'}
+            name="consentChecked"
+            animationDelay={Math.min(section.questions.length * 100, 500)}
+          />
         )}
       </div>
     </div>
@@ -156,6 +177,8 @@ function SectionRenderer({ sectionIndex }: { sectionIndex: number }) {
 export default function AssessmentForm() {
   const [currentSection, setCurrentSection] = useState(0);
   const [direction, setDirection] = useState<'forward' | 'backward'>('forward');
+  const [isExiting, setIsExiting] = useState(false);
+  const [shakeKey, setShakeKey] = useState(0);
   const [completedSections, setCompletedSections] = useState<Set<number>>(new Set());
   const [processingData, setProcessingData] = useState<ProcessingData | null>(null);
 
@@ -221,6 +244,9 @@ export default function AssessmentForm() {
   const totalSections = assessmentSections.length;
 
   const handleNext = async () => {
+    if (isExiting) {
+      return;
+    }
     const values = methods.getValues();
     const validator = sectionValidators[currentSection];
     if (!validator) {
@@ -231,18 +257,30 @@ export default function AssessmentForm() {
       Object.entries(result.errors).forEach(([field, message]) => {
         methods.setError(field as keyof AssessmentFormData, { message });
       });
+      setShakeKey(prev => prev + 1);
       return;
     }
     setCompletedSections(prev => new Set([...prev, currentSection]));
     setDirection('forward');
-    setCurrentSection(prev => Math.min(prev + 1, totalSections - 1));
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    setIsExiting(true);
+    setTimeout(() => {
+      setCurrentSection(prev => Math.min(prev + 1, totalSections - 1));
+      setIsExiting(false);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }, 200);
   };
 
   const handleBack = () => {
+    if (isExiting) {
+      return;
+    }
     setDirection('backward');
-    setCurrentSection(prev => Math.max(prev - 1, 0));
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    setIsExiting(true);
+    setTimeout(() => {
+      setCurrentSection(prev => Math.max(prev - 1, 0));
+      setIsExiting(false);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }, 200);
   };
 
   const handleNavigate = (index: number) => {
@@ -253,6 +291,9 @@ export default function AssessmentForm() {
   };
 
   const handleSubmit = async () => {
+    if (isExiting) {
+      return;
+    }
     const values = methods.getValues();
     const validator = sectionValidators[currentSection];
     if (!validator) {
@@ -263,6 +304,7 @@ export default function AssessmentForm() {
       Object.entries(result.errors).forEach(([field, message]) => {
         methods.setError(field as keyof AssessmentFormData, { message });
       });
+      setShakeKey(prev => prev + 1);
       return;
     }
 
@@ -311,7 +353,9 @@ export default function AssessmentForm() {
   }
 
   const isLastSection = currentSection === totalSections - 1;
-  const animClass = direction === 'forward' ? 'animate-slide-in-right' : 'animate-slide-in-left';
+  const exitClass = direction === 'forward' ? 'animate-slide-out-left' : 'animate-slide-out-right';
+  const enterClass = direction === 'forward' ? 'animate-slide-in-right' : 'animate-slide-in-left';
+  const animClass = isExiting ? exitClass : enterClass;
   const sectionTitles = assessmentSections.map(s => s.title);
 
   return (
@@ -343,7 +387,7 @@ export default function AssessmentForm() {
 
         <main className="mx-auto max-w-2xl px-6 pb-8">
           <div key={currentSection} className={animClass}>
-            <SectionRenderer sectionIndex={currentSection} />
+            <SectionRenderer sectionIndex={currentSection} shakeKey={shakeKey} />
           </div>
 
           <FormNavigation
@@ -352,6 +396,7 @@ export default function AssessmentForm() {
             onBack={handleBack}
             onNext={isLastSection ? handleSubmit : handleNext}
             isSubmitting={false}
+            disabled={isExiting}
           />
         </main>
 

--- a/src/components/assessment/FormNavigation.tsx
+++ b/src/components/assessment/FormNavigation.tsx
@@ -4,6 +4,7 @@ type FormNavigationProps = {
   onBack: () => void;
   onNext: () => void;
   isSubmitting?: boolean;
+  disabled?: boolean;
 };
 
 export default function FormNavigation({
@@ -12,6 +13,7 @@ export default function FormNavigation({
   onBack,
   onNext,
   isSubmitting,
+  disabled,
 }: FormNavigationProps) {
   const isLastSection = currentSection === totalSections - 1;
 
@@ -32,8 +34,8 @@ export default function FormNavigation({
         <button
           type="button"
           onClick={onNext}
-          disabled={isSubmitting}
-          className="rounded-lg bg-accent-blue px-6 py-3 text-base font-semibold text-white hover:bg-accent-blue-hover disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSubmitting || disabled}
+          className="rounded-lg bg-accent-blue px-6 py-3 text-base font-semibold text-white transition-all duration-150 hover:scale-[1.02] hover:bg-accent-blue-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isSubmitting
             ? 'Submitting...'

--- a/src/components/assessment/questions/ConsentCheckbox.tsx
+++ b/src/components/assessment/questions/ConsentCheckbox.tsx
@@ -4,12 +4,14 @@ import Link from 'next/link';
 import { useController, useFormContext } from 'react-hook-form';
 
 import type { AssessmentFormData } from '@/types/assessment';
+import { cn } from '@/utils/Helpers';
 
 type ConsentCheckboxProps = {
   name: keyof AssessmentFormData;
+  animationDelay?: number;
 };
 
-export default function ConsentCheckbox({ name }: ConsentCheckboxProps) {
+export default function ConsentCheckbox({ name, animationDelay = 0 }: ConsentCheckboxProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
     field,
@@ -17,7 +19,10 @@ export default function ConsentCheckbox({ name }: ConsentCheckboxProps) {
   } = useController({ name, control });
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <div className="flex items-start gap-3">
         <input
           id="consent-checkbox"

--- a/src/components/assessment/questions/DropdownQuestion.tsx
+++ b/src/components/assessment/questions/DropdownQuestion.tsx
@@ -13,6 +13,7 @@ type DropdownQuestionProps = {
   placeholder?: string;
   helpText?: string;
   required?: boolean;
+  animationDelay?: number;
 };
 
 export default function DropdownQuestion({
@@ -22,6 +23,7 @@ export default function DropdownQuestion({
   placeholder,
   helpText,
   required,
+  animationDelay = 0,
 }: DropdownQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -32,7 +34,10 @@ export default function DropdownQuestion({
   const value = typeof rawValue === 'string' ? rawValue : '';
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <label className="mb-1 block text-xl font-semibold text-text-primary">
         {label}
         {required && <span className="ml-1 text-score-red">*</span>}

--- a/src/components/assessment/questions/EmailQuestion.tsx
+++ b/src/components/assessment/questions/EmailQuestion.tsx
@@ -11,6 +11,7 @@ type EmailQuestionProps = {
   placeholder?: string;
   helpText?: string;
   required?: boolean;
+  animationDelay?: number;
 };
 
 export default function EmailQuestion({
@@ -19,6 +20,7 @@ export default function EmailQuestion({
   placeholder,
   helpText,
   required,
+  animationDelay = 0,
 }: EmailQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -32,7 +34,10 @@ export default function EmailQuestion({
   const errorId = `${inputId}-error`;
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <label htmlFor={inputId} className="mb-1 block text-xl font-semibold text-text-primary">
         {label}
         {required && <span className="ml-1 text-score-red" aria-hidden="true">*</span>}

--- a/src/components/assessment/questions/MultiSelectQuestion.tsx
+++ b/src/components/assessment/questions/MultiSelectQuestion.tsx
@@ -11,6 +11,7 @@ type MultiSelectQuestionProps = {
   label: string;
   options: OptionItem[];
   helpText?: string;
+  animationDelay?: number;
 };
 
 export default function MultiSelectQuestion({
@@ -18,6 +19,7 @@ export default function MultiSelectQuestion({
   label,
   options,
   helpText,
+  animationDelay = 0,
 }: MultiSelectQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -46,7 +48,10 @@ export default function MultiSelectQuestion({
   const errorId = `${groupId}-error`;
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <p id={groupId} className="mb-1 block text-xl font-semibold text-text-primary">{label}</p>
       {helpText && <p className="mb-4 text-sm text-text-secondary">{helpText}</p>}
       <div role="group" aria-labelledby={groupId} className="flex flex-col gap-3">

--- a/src/components/assessment/questions/NumberQuestion.tsx
+++ b/src/components/assessment/questions/NumberQuestion.tsx
@@ -14,6 +14,7 @@ type NumberQuestionProps = {
   prefix?: string;
   suffix?: string;
   min?: number;
+  animationDelay?: number;
 };
 
 export default function NumberQuestion({
@@ -24,6 +25,7 @@ export default function NumberQuestion({
   required,
   prefix,
   suffix,
+  animationDelay = 0,
 }: NumberQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -34,7 +36,10 @@ export default function NumberQuestion({
   const value = typeof rawValue === 'string' ? rawValue : '';
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <label className="mb-1 block text-xl font-semibold text-text-primary">
         {label}
         {required && <span className="ml-1 text-score-red">*</span>}

--- a/src/components/assessment/questions/RadioCardQuestion.tsx
+++ b/src/components/assessment/questions/RadioCardQuestion.tsx
@@ -11,6 +11,7 @@ type RadioCardQuestionProps = {
   label: string;
   options: OptionItem[];
   helpText?: string;
+  animationDelay?: number;
 };
 
 export default function RadioCardQuestion({
@@ -18,6 +19,7 @@ export default function RadioCardQuestion({
   label,
   options,
   helpText,
+  animationDelay = 0,
 }: RadioCardQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -56,7 +58,10 @@ export default function RadioCardQuestion({
   const errorId = `${groupId}-error`;
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <p id={groupId} className="mb-1 block text-xl font-semibold text-text-primary">{label}</p>
       {helpText && <p className="mb-4 text-sm text-text-secondary">{helpText}</p>}
       <div role="radiogroup" aria-labelledby={groupId} aria-required className="flex flex-col gap-3">

--- a/src/components/assessment/questions/TextQuestion.tsx
+++ b/src/components/assessment/questions/TextQuestion.tsx
@@ -12,6 +12,7 @@ type TextQuestionProps = {
   helpText?: string;
   maxLength?: number;
   required?: boolean;
+  animationDelay?: number;
 };
 
 export default function TextQuestion({
@@ -21,6 +22,7 @@ export default function TextQuestion({
   helpText,
   maxLength,
   required,
+  animationDelay = 0,
 }: TextQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -35,7 +37,10 @@ export default function TextQuestion({
   const errorId = `${inputId}-error`;
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <label htmlFor={inputId} className="mb-1 block text-xl font-semibold text-text-primary">
         {label}
         {required && <span className="ml-1 text-score-red" aria-hidden="true">*</span>}

--- a/src/components/assessment/questions/TextareaQuestion.tsx
+++ b/src/components/assessment/questions/TextareaQuestion.tsx
@@ -12,6 +12,7 @@ type TextareaQuestionProps = {
   helpText?: string;
   maxLength?: number;
   required?: boolean;
+  animationDelay?: number;
 };
 
 export default function TextareaQuestion({
@@ -21,6 +22,7 @@ export default function TextareaQuestion({
   helpText,
   maxLength,
   required,
+  animationDelay = 0,
 }: TextareaQuestionProps) {
   const { control } = useFormContext<AssessmentFormData>();
   const {
@@ -42,7 +44,10 @@ export default function TextareaQuestion({
   const errorId = `${textareaId}-error`;
 
   return (
-    <div className="animate-fade-in">
+    <div
+      className={cn(error ? 'animate-shake' : 'animate-fade-in')}
+      style={!error ? { animationDelay: `${animationDelay}ms` } : undefined}
+    >
       <label htmlFor={textareaId} className="mb-1 block text-xl font-semibold text-text-primary">
         {label}
         {required && <span className="ml-1 text-score-red" aria-hidden="true">*</span>}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -138,3 +138,42 @@
 .animate-fade-in {
   animation: fade-in 0.2s ease forwards;
 }
+@keyframes slide-out-left {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+}
+@keyframes slide-out-right {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+}
+.animate-slide-out-left {
+  animation: slide-out-left 0.2s ease forwards;
+}
+.animate-slide-out-right {
+  animation: slide-out-right 0.2s ease forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-in-right,
+  .animate-slide-in-left,
+  .animate-slide-out-left,
+  .animate-slide-out-right,
+  .animate-shake,
+  .animate-fade-in {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

- **Staggered question fade-in**: questions enter with 100ms stagger per index, capped at 500ms, via `animationDelay` prop forwarded through `QuestionDispatcher` to all 8 question components
- **Section exit animation**: `slide-out-left/right` keyframes (200ms) play before section change; `handleNext`/`handleBack`/`handleSubmit` are guarded against re-entry during exit; `FormNavigation` `Continue` button is disabled during exit
- **Error shake**: on validation failure, `shakeKey` increments; only fields with errors get a new React `key` (forcing remount + `animate-shake`); clean fields are unaffected — no spurious fade-in on failed submit
- **Button microinteractions**: `hover:scale-[1.02] active:scale-[0.98]` on Continue/Submit buttons only (Back link excluded)
- **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables all `animate-*` classes globally

## Test plan

- [ ] Questions stagger in (0ms, 100ms, 200ms...) on section entrance
- [ ] Section slides out left (forward) / right (backward) then new section slides in
- [ ] Clicking Continue with errors: only errored fields shake, others stay stable
- [ ] Clicking Continue twice with same error: shake re-triggers each time
- [ ] Continue/Submit button scales on hover and press; Back link does not
- [ ] Set OS to reduced motion preference — all animations disabled
- [ ] `npm run build`, `npm run lint`, `npm run test` all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)